### PR TITLE
Add --format=oldgnu option to tar

### DIFF
--- a/make.bash
+++ b/make.bash
@@ -51,5 +51,5 @@ cd ..
 env PYTHONPATH=${PWD}/anita-${ANITA_VERSION} python mkvm.py ${ARCH} ${RELEASE} ${DISK_SIZE}
 
 echo "Archiving wd0.img (this may take a while)"
-${TAR} -Szcf netbsd-${ARCH}-gce.tar.gz --transform s,${WORKDIR}/wd0.img,disk.raw, ${WORKDIR}/wd0.img
+${TAR} --format=oldgnu -Szcf netbsd-${ARCH}-gce.tar.gz --transform s,${WORKDIR}/wd0.img,disk.raw, ${WORKDIR}/wd0.img
 echo "Done. GCE image is netbsd-${ARCH}-gce.tar.gz."


### PR DESCRIPTION
According to that [documentation](https://cloud.google.com/compute/docs/import/import-existing-image), `tar` needs `--format=oldgnu` option. Otherwise,  it gives `The tar archive is not a valid image.` error while creating the image.